### PR TITLE
Fix missing sqlite dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "ejs": "^3.1.10",
         "express": "^5.1.0",
+        "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7"
       }
     },
@@ -2046,6 +2047,12 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/sqlite": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sqlite/-/sqlite-5.1.1.tgz",
+      "integrity": "sha512-oBkezXa2hnkfuJwUo44Hl9hS3er+YFtueifoajrgidvqsJRQFpc5fKoAkAor1O5ZnLoa28GBScfHXs8j0K358Q==",
+      "license": "MIT"
     },
     "node_modules/sqlite3": {
       "version": "5.1.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "ejs": "^3.1.10",
     "express": "^5.1.0",
+    "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- install `sqlite` module so the server can import `{ open }` from `sqlite`

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685444c55ecc8320a6fe7980c4c7872a